### PR TITLE
Remove magic numbers and cleanup extra whitespaces from the code

### DIFF
--- a/ghost-in-the-shell-op.go
+++ b/ghost-in-the-shell-op.go
@@ -88,12 +88,12 @@ func draw_background() {
 		shuffle(positions)
 		positions = decrease_cells(positions)
 	}
-	
+
 	for _, position := range positions {
 		cell_num := rand.Intn(10)
 		cell_char := rune(cell_num) + '0'
-		
- 		// SetCell(x, y, Character, ForegroundColor, BackgroundColor)		
+
+		// SetCell(x, y, Character, ForegroundColor, BackgroundColor)		
 		termbox.SetCell(position.x, position.y, cell_char, termbox.ColorGreen, termbox.ColorDefault)
 	}
 }
@@ -110,7 +110,7 @@ func init_positions() {
 
 func decrease_cells(data []Position) (result []Position) {
 	n := 0
-	size := len(data) / 5 * 3
+	size := len(data) * 60 / 100 // decrease data size to 60% of it's initial size
 
 	if size < DEC_TH {
 		return result
@@ -123,7 +123,7 @@ func decrease_cells(data []Position) (result []Position) {
 		result = append(result, value)
 		n++
 	}
-	
+
 	return result
 }
 


### PR DESCRIPTION
In function `decrease_cells`, the Position data size was set to `size := len(data) / 5 * 3`, essentially decreasing the size of the Position struct to 60% of it's initial size. This PR removes the confusing magic numbers with a proper `size := len(data) * 60 / 100` and adds a comment on the side, making the code much more human read-able.

P. S: Please add a license to the repository.